### PR TITLE
Make the add button insensitive if the entry is blank

### DIFF
--- a/src/Window.vala
+++ b/src/Window.vala
@@ -380,6 +380,7 @@ namespace Mindi {
 
             var button = new Button.from_icon_name ("list-add-symbolic", IconSize.SMALL_TOOLBAR);
             button.tooltip_text = _("Add");
+            button.sensitive = false;
             var clip_button = new Button.from_icon_name ("edit-paste-symbolic", IconSize.SMALL_TOOLBAR);
             clip_button.tooltip_text = _("Paste");
             entry = new Gtk.Entry ();
@@ -406,6 +407,10 @@ namespace Mindi {
             button.clicked.connect (() => {
                 add_url_clicked (stream);
                 add_url_popover.hide ();
+            });
+
+            entry.changed.connect (() => {
+                button.sensitive = entry.text != "" ? true : false;
             });
 
             open_stream = new Gtk.Button.with_label (_ ("Add URL"));


### PR DESCRIPTION
I think this will improve usability, although an error is shown if the entry is blank.

### Changes Summary

![peek 2019-01-26 12-52](https://user-images.githubusercontent.com/26003928/51782319-b399e200-2169-11e9-8a4f-faa7a9c94cd4.gif)

* If the entry in the popover is blank, the add button will be insensitive
